### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/_infra/kustomize/base/ingress.yaml
+++ b/_infra/kustomize/base/ingress.yaml
@@ -58,4 +58,4 @@ spec:
   tls:
     - hosts:
         - FQDN_PLACEHOLDER
-      secretName: fapi-pep-4s-tls-cert
+      secretName: fapi-pep-rs-tls-cert


### PR DESCRIPTION
Correct TLS cert name for ig studio

Issue: https://github.com/secureapigateway/secureapigateway/issues/1676