### PR TITLE
OPENIG-9209 Update client certificate configuration

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -213,7 +213,7 @@
             "name": "FapiContextInitializerFilter",
             "type": "FapiContextInitializerFilter",
             "config": {
-              "tlsCertificateHeaderName": "ssl-client-cert"
+              "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}"
             }
           },
           {

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -201,7 +201,7 @@
             "name": "FapiContextInitializerFilter",
             "type": "FapiContextInitializerFilter",
             "config": {
-              "tlsCertificateHeaderName": "ssl-client-cert"
+              "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}"
             }
           },
           {


### PR DESCRIPTION
Due to OPENIN-9209 changes, the configuraiton to retrieve the client certificate must be updated to use the new Expression.