### PR TITLE
1709: Update IG Components to use 2025.6.1 Artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <properties>
         <secure-api-gateway.version>4.0.5-SNAPSHOT</secure-api-gateway.version>
-        <openig.version>2025.6.0-SNAPSHOT</openig.version>
+        <openig.version>2025.6.1</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-fapi-pep-rs-core-docker/Dockerfile
+++ b/secure-api-gateway-fapi-pep-rs-core-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.6.0-latest-postcommit-fapi
+ARG base_image=gcr.io/forgerock-io/ig:2025.6.1-fapi
 
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this


### PR DESCRIPTION
- Bump pom.xml to use 2025.6.1 of openIG
- Bump docker image to 2025.6.1-fapi

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1709