### PR TITLE
OpenIG-9633: SAPIG 5.0.2 Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </parent>
 
     <properties>
-        <secure-api-gateway.fapi-pep-as.version>5.0.1-SNAPSHOT</secure-api-gateway.fapi-pep-as.version>
+        <secure-api-gateway.fapi-pep-as.version>5.0.2-SNAPSHOT</secure-api-gateway.fapi-pep-as.version>
         <openig.version>2025.9.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>


### PR DESCRIPTION
Bump fapi-pep-as version to latest snapshot version

Issue: https://pingidentity.atlassian.net/jira/software/c/projects/OPENIG/boards/1322?selectedIssue=OPENIG-9633